### PR TITLE
vmops: Fixes setting disk QoS specs

### DIFF
--- a/hyperv/nova/vmops.py
+++ b/hyperv/nova/vmops.py
@@ -1073,8 +1073,8 @@ class VMOps(object):
         if min_iops or max_iops:
             local_disks = self._get_instance_local_disks(instance.name)
             for disk_path in local_disks:
-                self._vmutils.set_disk_qos_specs(instance.name, disk_path,
-                                                 min_iops, max_iops)
+                self._vmutils.set_disk_qos_specs(disk_path,
+                                                 max_iops, min_iops)
 
     def _get_instance_local_disks(self, instance_name):
         instance_path = self._pathutils.get_instance_dir(instance_name)

--- a/hyperv/tests/unit/test_vmops.py
+++ b/hyperv/tests/unit/test_vmops.py
@@ -1765,9 +1765,9 @@ class VMOpsTestCase(test_base.HyperVBaseTestCase):
 
         self._vmops._set_instance_disk_qos_specs(mock_instance)
         mock_get_local_disks.assert_called_once_with(mock_instance.name)
-        expected_calls = [mock.call(mock_instance.name, disk_path,
-                                    mock.sentinel.min_iops,
-                                    mock.sentinel.max_iops)
+        expected_calls = [mock.call(disk_path,
+                                    mock.sentinel.max_iops,
+                                    mock.sentinel.min_iops)
                           for disk_path in mock_local_disks]
         mock_set_qos_specs.assert_has_calls(expected_calls)
 


### PR DESCRIPTION
os-win vmutils method does not accept a vm_name argument, which
is passed from vmops, resulting an Exception when trying to set
disk QoS.

Change-Id: I8cc60bd44f7761b61cec19df1526ff5daba65906